### PR TITLE
Move black and autoflake to dev-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,15 +24,15 @@ thriftpyi = "thriftpyi.cli:main"
 python = "^3.7"
 click = "^7.0"
 jinja2 = "^2.10"
-black = "^19.3b0"
 thriftpy2 = "^0.4.2"
-autoflake = "^1.3"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.12"
 pre-commit = "^1.16"
 mypy = "^0.701.0"
 pylint = "^2.3"
+black = "^19.3b0"
+autoflake = "^1.3"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
These tools are presumably needed only to run checks on code at development time, and not at runtime. Moving them to `dev-dependencies` reduces the dependencies that need to be installed by projects using this package and limits the chance of version conflicts.