### PR TITLE
Fix empty exceptions 

### DIFF
--- a/example/interfaces/shared.thrift
+++ b/example/interfaces/shared.thrift
@@ -2,6 +2,8 @@ exception NotFound {
     1: optional string message = "Not Found"
 }
 
+exception EmptyException {}
+
 
 struct LimitOffset {
     1: optional i32 limit

--- a/src/thriftpyi/templates/stub.html
+++ b/src/thriftpyi/templates/stub.html
@@ -12,6 +12,8 @@ from . import {{ import }}
 class {{ error.name }}(Exception):
 {%- for field in error.fields %}
     {{ field.name }}: {{ field.type }}{% if field.value is not none %} = {{ field.value }}{% endif %}
+{% else -%}
+    pass
 {%- endfor %}
 {% endfor %}
 

--- a/tests/stubs/expected/async/shared.pyi
+++ b/tests/stubs/expected/async/shared.pyi
@@ -4,6 +4,9 @@ from typing import *
 class NotFound(Exception):
     message: Optional[str] = "Not Found"
 
+class EmptyException(Exception):
+    pass
+
 @dataclass
 class LimitOffset:
     limit: Optional[int] = None

--- a/tests/stubs/expected/optional/shared.pyi
+++ b/tests/stubs/expected/optional/shared.pyi
@@ -4,6 +4,9 @@ from typing import *
 class NotFound(Exception):
     message: Optional[str] = "Not Found"
 
+class EmptyException(Exception):
+    pass
+
 @dataclass
 class LimitOffset:
     limit: Optional[int] = None

--- a/tests/stubs/expected/sync/shared.pyi
+++ b/tests/stubs/expected/sync/shared.pyi
@@ -4,6 +4,9 @@ from typing import *
 class NotFound(Exception):
     message: Optional[str] = "Not Found"
 
+class EmptyException(Exception):
+    pass
+
 @dataclass
 class LimitOffset:
     limit: Optional[int] = None


### PR DESCRIPTION
To fix #27, we can easily check for an empty field list when emitting exceptions, and emit `pass` if none are found.