### PR TITLE
Support dataclass semantics for exceptions (same as structs)

### DIFF
--- a/src/thriftpyi/templates/stub.html
+++ b/src/thriftpyi/templates/stub.html
@@ -9,6 +9,7 @@ from . import {{ import }}
 
 
 {% for error in errors %}
+@dataclass
 class {{ error.name }}(Exception):
 {%- for field in error.fields %}
     {{ field.name }}: {{ field.type }}{% if field.value is not none %} = {{ field.value }}{% endif %}


### PR DESCRIPTION
As far as I can tell, Thrift exceptions can be instantiated the same way as structs (at least using `thriftpy2`), so this adds the `@dataclass` decorator to exceptions as well. We hotpatched this in our project, but wanted to contribute back :) 