### PR TITLE
Include fields on Exceptions, this addresses missing fields on Exception structs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "thrift-pyi"
-version = "0.5.0"
+version = "0.6.0"
 description = "This is simple `.pyi` stubs generator from thrift interfaces"
 readme = "README.rst"
 repository = "https://github.com/unmade/thrift-pyi"

--- a/src/thriftpyi/proxies.py
+++ b/src/thriftpyi/proxies.py
@@ -69,7 +69,7 @@ class TModuleProxy:
         if fields:
             methods.append(Method(name="__init__", args=fields))
 
-        return ModuleItem(name=texc.__name__, methods=methods)
+        return ModuleItem(name=texc.__name__, methods=methods, fields=fields)
 
     @classmethod
     def _make_service(cls, tservice) -> ModuleItem:

--- a/tests/stubs/expected/async/shared.pyi
+++ b/tests/stubs/expected/async/shared.pyi
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from typing import *
 
 class NotFound(Exception):
+    message: Optional[str] = "Not Found"
+
     def __init__(self, message: Optional[str] = "Not Found") -> None: ...
 
 class EmptyException(Exception): ...

--- a/tests/stubs/expected/optional/shared.pyi
+++ b/tests/stubs/expected/optional/shared.pyi
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from typing import *
 
 class NotFound(Exception):
+    message: Optional[str] = "Not Found"
+
     def __init__(self, message: Optional[str] = "Not Found") -> None: ...
 
 class EmptyException(Exception): ...

--- a/tests/stubs/expected/sync/shared.pyi
+++ b/tests/stubs/expected/sync/shared.pyi
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from typing import *
 
 class NotFound(Exception):
+    message: Optional[str] = "Not Found"
+
     def __init__(self, message: Optional[str] = "Not Found") -> None: ...
 
 class EmptyException(Exception): ...


### PR DESCRIPTION
We had solved this in the old version of `thrift-pyi` ([discussion here](https://github.com/unmade/thrift-pyi/pull/34)) but this appears to be a regression in latest version.