### PR TITLE
Use Python APIs for linter dependencies

### DIFF
--- a/poetry-installer-error-5dryhakp.log
+++ b/poetry-installer-error-5dryhakp.log
@@ -1,0 +1,8 @@
+dyld[52292]: Library not loaded: @loader_path/../../../../Python.framework/Versions/3.11/Python
+  Referenced from: <16376C03-0DA9-3714-9207-5AF8D546EED4> /Users/frank/Library/Application Support/pypoetry/venv/bin/python3.11
+  Reason: tried: '/Users/frank/Library/Application Support/pypoetry/venv/bin/../../../../Python.framework/Versions/3.11/Python' (no such file), '/Library/Frameworks/Python.framework/Versions/3.11/Python' (no such file), '/System/Library/Frameworks/Python.framework/Versions/3.11/Python' (no such file, not in dyld cache)
+
+Traceback:
+
+  File "<stdin>", line 923, in main
+  File "<stdin>", line 562, in run

--- a/poetry-installer-error-ez4ywbcq.log
+++ b/poetry-installer-error-ez4ywbcq.log
@@ -1,0 +1,8 @@
+dyld[52524]: Library not loaded: @loader_path/../../../../Python.framework/Versions/3.11/Python
+  Referenced from: <16376C03-0DA9-3714-9207-5AF8D546EED4> /Users/frank/Library/Application Support/pypoetry/venv/bin/python3.11
+  Reason: tried: '/Users/frank/Library/Application Support/pypoetry/venv/bin/../../../../Python.framework/Versions/3.11/Python' (no such file), '/Library/Frameworks/Python.framework/Versions/3.11/Python' (no such file), '/System/Library/Frameworks/Python.framework/Versions/3.11/Python' (no such file, not in dyld cache)
+
+Traceback:
+
+  File "<stdin>", line 923, in main
+  File "<stdin>", line 562, in run

--- a/poetry-installer-error-njrgrd_6.log
+++ b/poetry-installer-error-njrgrd_6.log
@@ -1,0 +1,8 @@
+dyld[52433]: Library not loaded: @loader_path/../../../../Python.framework/Versions/3.11/Python
+  Referenced from: <16376C03-0DA9-3714-9207-5AF8D546EED4> /Users/frank/Library/Application Support/pypoetry/venv/bin/python3.11
+  Reason: tried: '/Users/frank/Library/Application Support/pypoetry/venv/bin/../../../../Python.framework/Versions/3.11/Python' (no such file), '/Library/Frameworks/Python.framework/Versions/3.11/Python' (no such file), '/System/Library/Frameworks/Python.framework/Versions/3.11/Python' (no such file, not in dyld cache)
+
+Traceback:
+
+  File "<stdin>", line 923, in main
+  File "<stdin>", line 562, in run

--- a/src/thriftpyi/main.py
+++ b/src/thriftpyi/main.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from autoflake import fix_code
+from black import format_str, FileMode
 import thriftpy2
 
 from thriftpyi import files, stubs
@@ -32,13 +34,13 @@ def thriftpyi(  # pylint: disable=too-many-locals
             strict_fields=strict_fields,
             strict_methods=strict_methods,
         )
-        files.save(ast_unparse(stub), to=output_dir / path.with_suffix(".pyi").name)
+        files.save(lint(ast_unparse(stub)), to=output_dir / path.with_suffix(".pyi").name)
 
     lint(output_dir)
 
 
-def lint(output_dir: Path) -> None:
-    subprocess.check_call([f"autoflake -i -r {output_dir.joinpath('*')}"], shell=True)
-    subprocess.check_call(
-        ["black", "--pyi", "--quiet", *list(output_dir.glob("*.pyi"))]
-    )
+def lint(code_str: str) -> str:
+    formatted_code_str = fix_code(code_str)
+    formatted_code_str = format_str(formatted_code_str, mode=FileMode())
+
+    return formatted_code_str

--- a/src/thriftpyi/main.py
+++ b/src/thriftpyi/main.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 
-from autoflake import fix_code
-from black import format_str, FileMode
 import thriftpy2
+from autoflake import fix_code
+from black import FileMode, format_str
 
 from thriftpyi import files, stubs
 from thriftpyi.compat import ast_unparse
@@ -23,7 +22,7 @@ def thriftpyi(  # pylint: disable=too-many-locals
     interfaces = files.list_interfaces(interfaces_dir)
 
     stub = stubs.build_init(path.stem for path in interfaces)
-    files.save(ast_unparse(stub), to=output_dir / "__init__.pyi")
+    files.save(lint(ast_unparse(stub)), to=output_dir / "__init__.pyi")
 
     for path in interfaces:
         tmodule = thriftpy2.load(str(path))
@@ -34,9 +33,9 @@ def thriftpyi(  # pylint: disable=too-many-locals
             strict_fields=strict_fields,
             strict_methods=strict_methods,
         )
-        files.save(lint(ast_unparse(stub)), to=output_dir / path.with_suffix(".pyi").name)
-
-    lint(output_dir)
+        files.save(
+            lint(ast_unparse(stub)), to=output_dir / path.with_suffix(".pyi").name
+        )
 
 
 def lint(code_str: str) -> str:

--- a/src/thriftpyi/main.py
+++ b/src/thriftpyi/main.py
@@ -42,4 +42,4 @@ def lint(code_str: str) -> str:
     formatted_code_str = fix_code(code_str)
     formatted_code_str = format_str(formatted_code_str, mode=FileMode())
 
-    return formatted_code_str
+    return str(formatted_code_str)


### PR DESCRIPTION
Although `thrift-pyi` currently has pinned dependencies against `autoflake` and `black`, calling a CLI subprocess is not guaranteed to actually use those specific dependent packages in lieu of other system installed libraries. This is especially apparent in a Bazel monorepo where commands are executed in quarantined sandbox environments. I'm not sure if `virtualenv` works ok with the current setup, but I think using the internal APIs may be safer in general, but I am curious to hear your opinions.