### PR TITLE
Use executing Python environment for linter dependencies

### DIFF
--- a/src/thriftpyi/main.py
+++ b/src/thriftpyi/main.py
@@ -39,13 +39,20 @@ def thriftpyi(  # pylint: disable=too-many-locals
 
 
 def lint(output_dir: Path) -> None:
+    python_executable = sys.executable
+    if not python_executable:
+        raise RuntimeError(
+            "Python executable not found. Make sure that Python is "
+            "installed and the path is set correctly."
+        )
+
     subprocess.check_call(
-        [f"{sys.executable} -m autoflake -i -r {output_dir.joinpath('*')}"],
+        [f"{python_executable} -m autoflake -i -r {output_dir.joinpath('*')}"],
         shell=True,
     )
     subprocess.check_call(
         [
-            f"{sys.executable}",
+            f"{python_executable}",
             "-m",
             "black",
             "--pyi",

--- a/src/thriftpyi/main.py
+++ b/src/thriftpyi/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import thriftpy2
@@ -38,7 +39,17 @@ def thriftpyi(  # pylint: disable=too-many-locals
 
 
 def lint(output_dir: Path) -> None:
-    subprocess.check_call([f"autoflake -i -r {output_dir.joinpath('*')}"], shell=True)
     subprocess.check_call(
-        ["black", "--pyi", "--quiet", *list(output_dir.glob("*.pyi"))]
+        [f"{sys.executable} -m autoflake -i -r {output_dir.joinpath('*')}"],
+        shell=True,
+    )
+    subprocess.check_call(
+        [
+            f"{sys.executable}",
+            "-m",
+            "black",
+            "--pyi",
+            "--quiet",
+            *list(output_dir.glob("*.pyi")),
+        ]
     )


### PR DESCRIPTION
Carryover from https://github.com/unmade/thrift-pyi/pull/45

Pasting relevant discussion below:

> Although thrift-pyi currently has pinned dependencies against autoflake and black, calling a CLI subprocess is not guaranteed to actually use those specific dependent packages in lieu of other system installed libraries. This is especially apparent in a Bazel monorepo where commands are executed in quarantined sandbox environments. I'm not sure if virtualenv works ok with the current setup, but I think using the internal APIs may be safer in general, but I am curious to hear your opinions.

Specifically re the concern in https://github.com/unmade/thrift-pyi/pull/45#issuecomment-1789693226, I figured since both `None` and `""` essentially prevent the code from running anyway, we may as well just have it return an informative error.

If you wanna be more sure of compatibility for different scenarios, I think the best we can do with this solution is to do some `if/else` check to see if `sys.executable` exists, and if not, run the old version of the function. LMK if you want me to do that - at this point I can't tell if having that branch would be too weird/hacky so I'm happy to go with whatever you prefer.