### PR TITLE
Use type aliases for primitive types to keep meta information about original Thrift type

### DIFF
--- a/example/app/interfaces/_typedefs.pyi
+++ b/example/app/interfaces/_typedefs.pyi
@@ -1,0 +1,10 @@
+from typing import Annotated
+
+Binary = Annotated[bytes, {"thrift_type": "BINARY"}]
+Bool = Annotated[bool, {"thrift_type": "BOOL"}]
+Byte = Annotated[int, {"thrift_type": "BYTE"}]
+Double = Annotated[float, {"thrift_type": "DOUBLE"}]
+I16 = Annotated[int, {"thrift_type": "I16"}]
+I32 = Annotated[int, {"thrift_type": "I32"}]
+I64 = Annotated[int, {"thrift_type": "I64"}]
+String = Annotated[str, {"thrift_type": "STRING"}]

--- a/example/app/interfaces/dates.pyi
+++ b/example/app/interfaces/dates.pyi
@@ -1,15 +1,16 @@
 from dataclasses import dataclass
 from typing import *
+from . import _typedefs
 
 @dataclass
 class DateTime:
-    year: int
-    month: int
-    day: int
-    hour: int
-    minute: int
-    second: int
-    microsecond: Optional[int] = None
+    year: _typedefs.I16
+    month: _typedefs.Byte
+    day: _typedefs.Byte
+    hour: _typedefs.I16
+    minute: _typedefs.Byte
+    second: _typedefs.Byte
+    microsecond: Optional[_typedefs.I64] = None
 
 @dataclass
 class Date: ...

--- a/example/app/interfaces/shared.pyi
+++ b/example/app/interfaces/shared.pyi
@@ -1,21 +1,22 @@
 from dataclasses import dataclass
 from typing import *
+from . import _typedefs
 
 class NotFound(Exception):
-    message: Optional[str] = "Not Found"
+    message: Optional[_typedefs.String] = "Not Found"
 
-    def __init__(self, message: Optional[str] = "Not Found") -> None: ...
+    def __init__(self, message: Optional[_typedefs.String] = "Not Found") -> None: ...
 
 class EmptyException(Exception): ...
 
 @dataclass
 class LimitOffset:
-    limit: Optional[int] = None
-    offset: Optional[int] = None
+    limit: Optional[_typedefs.I32] = None
+    offset: Optional[_typedefs.I32] = None
 
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
 
 class Service:
-    def ping(self) -> str: ...
+    def ping(self) -> _typedefs.String: ...

--- a/example/app/interfaces/todo.pyi
+++ b/example/app/interfaces/todo.pyi
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import *
+from . import _typedefs
 from . import dates
 from . import shared
 
@@ -11,32 +12,32 @@ class TodoType(IntEnum):
 
 @dataclass
 class TodoItem:
-    id: int
-    text: str
+    id: _typedefs.I32
+    text: _typedefs.String
     type: TodoType
     created: dates.DateTime
-    is_deleted: bool
-    picture: Optional[bytes] = None
-    is_favorite: bool = False
+    is_deleted: _typedefs.Bool
+    picture: Optional[_typedefs.Binary] = None
+    is_favorite: _typedefs.Bool = False
 
 @dataclass
 class TodoCounter:
-    todos: Dict[int, TodoItem] = field(default_factory=dict)
-    plain_ids: Set[int] = field(default_factory=lambda: {1, 2, 3})
-    note_ids: List[int] = field(default_factory=list)
-    checkboxes_ids: Set[int] = field(default_factory=set)
+    todos: Dict[_typedefs.I32, TodoItem] = field(default_factory=dict)
+    plain_ids: Set[_typedefs.I32] = field(default_factory=lambda: {1, 2, 3})
+    note_ids: List[_typedefs.I32] = field(default_factory=list)
+    checkboxes_ids: Set[_typedefs.I32] = field(default_factory=set)
 
 default_created_date: dates.DateTime = dates.DateTime(
     year=2024, month=12, day=25, hour=0, minute=0, second=0, microsecond=0
 )
 
 class Todo:
-    def create(self, text: str, type: TodoType) -> int: ...
+    def create(self, text: _typedefs.String, type: TodoType) -> _typedefs.I32: ...
     def update(self, item: TodoItem) -> None: ...
-    def get(self, id: int) -> TodoItem: ...
+    def get(self, id: _typedefs.I32) -> TodoItem: ...
     def all(self, pager: shared.LimitOffset) -> List[TodoItem]: ...
-    def filter(self, ids: List[int]) -> List[TodoItem]: ...
-    def stats(self) -> Dict[int, float]: ...
-    def types(self) -> Set[int]: ...
+    def filter(self, ids: List[_typedefs.I32]) -> List[TodoItem]: ...
+    def stats(self) -> Dict[_typedefs.I32, _typedefs.Double]: ...
+    def types(self) -> Set[_typedefs.I16]: ...
     def groupby(self) -> Dict[TodoType, List[TodoItem]]: ...
-    def ping(self) -> str: ...
+    def ping(self) -> _typedefs.String: ...

--- a/example/app/interfaces/todo_v2.pyi
+++ b/example/app/interfaces/todo_v2.pyi
@@ -1,1 +1,3 @@
+from . import _typedefs
+
 class Todo: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "thrift-pyi"
-version = "1.2.0"
+version = "2.0.0"
 description = "This is simple `.pyi` stubs generator from thrift interfaces"
 readme = "README.rst"
 repository = "https://github.com/unmade/thrift-pyi"

--- a/src/thriftpyi/main.py
+++ b/src/thriftpyi/main.py
@@ -24,6 +24,9 @@ def thriftpyi(  # pylint: disable=too-many-locals
     stub = stubs.build_init(path.stem for path in interfaces)
     files.save(ast.unparse(stub), to=output_dir / "__init__.pyi")
 
+    stub = stubs.build_typedefs()
+    files.save(ast.unparse(stub), to=output_dir / "_typedefs.pyi")
+
     for path in interfaces:
         tmodule = thriftpy2.load(str(path))
         proxy = TModuleProxy(tmodule)

--- a/src/thriftpyi/stubs.py
+++ b/src/thriftpyi/stubs.py
@@ -56,12 +56,7 @@ def build_typedefs() -> ast.Module:
         ast.ClassDef(
             name="Metadata",
             bases=[],
-            keywords=[
-                ast.keyword(
-                    arg="frozen",
-                    value=ast.Constant(value=True),
-                ),
-            ],
+            keywords=[],
             body=[
                 ast.AnnAssign(
                     target=ast.Name(id="thrift_type"),
@@ -73,7 +68,12 @@ def build_typedefs() -> ast.Module:
                 ast.Call(
                     func=ast.Name(id="dataclass"),
                     args=[],
-                    keywords=[],
+                    keywords=[
+                        ast.keyword(
+                            arg="frozen",
+                            value=ast.Constant(value=True),
+                        ),
+                    ],
                 ),
             ],
         ),

--- a/src/thriftpyi/stubs.py
+++ b/src/thriftpyi/stubs.py
@@ -44,10 +44,39 @@ def build_typedefs() -> ast.Module:
 
     body: list[ast.stmt] = [
         ast.ImportFrom(
+            module="dataclasses",
+            names=[ast.alias(name="dataclass")],
+            level=0,
+        ),
+        ast.ImportFrom(
             module="typing",
             names=[ast.alias(name="Annotated")],
             level=0,
-        )
+        ),
+        ast.ClassDef(
+            name="Metadata",
+            bases=[],
+            keywords=[
+                ast.keyword(
+                    arg="frozen",
+                    value=ast.Constant(value=True),
+                ),
+            ],
+            body=[
+                ast.AnnAssign(
+                    target=ast.Name(id="thrift_type"),
+                    annotation=ast.Name(id="str"),
+                    simple=1,
+                ),
+            ],
+            decorator_list=[
+                ast.Call(
+                    func=ast.Name(id="dataclass"),
+                    args=[],
+                    keywords=[],
+                ),
+            ],
+        ),
     ]
 
     for alias, (base_type, thrift_type) in types_map.items():
@@ -58,9 +87,15 @@ def build_typedefs() -> ast.Module:
                 slice=ast.Tuple(
                     elts=[
                         ast.Name(id=base_type),
-                        ast.Dict(
-                            keys=[ast.Constant(value="thrift_type")],
-                            values=[ast.Constant(value=thrift_type)],
+                        ast.Call(
+                            func=ast.Name(id="Metadata"),
+                            args=[],
+                            keywords=[
+                                ast.keyword(
+                                    arg="thrift_type",
+                                    value=ast.Constant(value=thrift_type),
+                                ),
+                            ],
                         ),
                     ],
                 ),

--- a/src/thriftpyi/utils.py
+++ b/src/thriftpyi/utils.py
@@ -47,43 +47,43 @@ def get_python_type(ttype: int, meta: List) -> str:
 
 def _get_bool(meta: List) -> str:
     del meta
-    return "bool"
+    return "_typedefs.Bool"
 
 
 def _get_double(meta: List) -> str:
     del meta
-    return "float"
+    return "_typedefs.Double"
 
 
 def _get_byte(meta: List) -> str:
     del meta
-    return "int"
+    return "_typedefs.Byte"
 
 
 def _get_binary(meta: List) -> str:
     del meta
-    return "bytes"
+    return "_typedefs.Binary"
 
 
 def _get_i16(meta: List) -> str:
     del meta
-    return "int"
+    return "_typedefs.I16"
 
 
 def _get_i32(meta: List) -> str:
     if meta and meta[0] is not None:
         return f"{meta[0].__module__}.{meta[0].__name__}"
-    return "int"
+    return "_typedefs.I32"
 
 
 def _get_i64(meta: List) -> str:
     del meta
-    return "int"
+    return "_typedefs.I64"
 
 
 def _get_str(meta: List) -> str:
     del meta
-    return "str"
+    return "_typedefs.String"
 
 
 def _get_struct(meta: List) -> str:

--- a/tests/stubs/expected/async/_typedefs.pyi
+++ b/tests/stubs/expected/async/_typedefs.pyi
@@ -1,0 +1,10 @@
+from typing import Annotated
+
+Binary = Annotated[bytes, {"thrift_type": "BINARY"}]
+Bool = Annotated[bool, {"thrift_type": "BOOL"}]
+Byte = Annotated[int, {"thrift_type": "BYTE"}]
+Double = Annotated[float, {"thrift_type": "DOUBLE"}]
+I16 = Annotated[int, {"thrift_type": "I16"}]
+I32 = Annotated[int, {"thrift_type": "I32"}]
+I64 = Annotated[int, {"thrift_type": "I64"}]
+String = Annotated[str, {"thrift_type": "STRING"}]

--- a/tests/stubs/expected/async/_typedefs.pyi
+++ b/tests/stubs/expected/async/_typedefs.pyi
@@ -1,10 +1,15 @@
+from dataclasses import dataclass
 from typing import Annotated
 
-Binary = Annotated[bytes, {"thrift_type": "BINARY"}]
-Bool = Annotated[bool, {"thrift_type": "BOOL"}]
-Byte = Annotated[int, {"thrift_type": "BYTE"}]
-Double = Annotated[float, {"thrift_type": "DOUBLE"}]
-I16 = Annotated[int, {"thrift_type": "I16"}]
-I32 = Annotated[int, {"thrift_type": "I32"}]
-I64 = Annotated[int, {"thrift_type": "I64"}]
-String = Annotated[str, {"thrift_type": "STRING"}]
+@dataclass(frozen=True)
+class Metadata:
+    thrift_type: str
+
+Binary = Annotated[bytes, Metadata(thrift_type="BINARY")]
+Bool = Annotated[bool, Metadata(thrift_type="BOOL")]
+Byte = Annotated[int, Metadata(thrift_type="BYTE")]
+Double = Annotated[float, Metadata(thrift_type="DOUBLE")]
+I16 = Annotated[int, Metadata(thrift_type="I16")]
+I32 = Annotated[int, Metadata(thrift_type="I32")]
+I64 = Annotated[int, Metadata(thrift_type="I64")]
+String = Annotated[str, Metadata(thrift_type="STRING")]

--- a/tests/stubs/expected/async/dates.pyi
+++ b/tests/stubs/expected/async/dates.pyi
@@ -1,15 +1,16 @@
 from dataclasses import dataclass
 from typing import *
+from . import _typedefs
 
 @dataclass
 class DateTime:
-    year: int
-    month: int
-    day: int
-    hour: int
-    minute: int
-    second: int
-    microsecond: Optional[int] = None
+    year: _typedefs.I16
+    month: _typedefs.Byte
+    day: _typedefs.Byte
+    hour: _typedefs.I16
+    minute: _typedefs.Byte
+    second: _typedefs.Byte
+    microsecond: Optional[_typedefs.I64] = None
 
 @dataclass
 class Date: ...

--- a/tests/stubs/expected/async/shared.pyi
+++ b/tests/stubs/expected/async/shared.pyi
@@ -1,21 +1,22 @@
 from dataclasses import dataclass
 from typing import *
+from . import _typedefs
 
 class NotFound(Exception):
-    message: Optional[str] = "Not Found"
+    message: Optional[_typedefs.String] = "Not Found"
 
-    def __init__(self, message: Optional[str] = "Not Found") -> None: ...
+    def __init__(self, message: Optional[_typedefs.String] = "Not Found") -> None: ...
 
 class EmptyException(Exception): ...
 
 @dataclass
 class LimitOffset:
-    limit: Optional[int] = None
-    offset: Optional[int] = None
+    limit: Optional[_typedefs.I32] = None
+    offset: Optional[_typedefs.I32] = None
 
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
 
 class Service:
-    async def ping(self) -> str: ...
+    async def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/async/todo.pyi
+++ b/tests/stubs/expected/async/todo.pyi
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import *
+from . import _typedefs
 from . import dates
 from . import shared
 
@@ -11,32 +12,32 @@ class TodoType(IntEnum):
 
 @dataclass
 class TodoItem:
-    id: int
-    text: str
+    id: _typedefs.I32
+    text: _typedefs.String
     type: TodoType
     created: dates.DateTime
-    is_deleted: bool
-    picture: Optional[bytes] = None
-    is_favorite: bool = False
+    is_deleted: _typedefs.Bool
+    picture: Optional[_typedefs.Binary] = None
+    is_favorite: _typedefs.Bool = False
 
 @dataclass
 class TodoCounter:
-    todos: Dict[int, TodoItem] = field(default_factory=dict)
-    plain_ids: Set[int] = field(default_factory=lambda: {1, 2, 3})
-    note_ids: List[int] = field(default_factory=list)
-    checkboxes_ids: Set[int] = field(default_factory=set)
+    todos: Dict[_typedefs.I32, TodoItem] = field(default_factory=dict)
+    plain_ids: Set[_typedefs.I32] = field(default_factory=lambda: {1, 2, 3})
+    note_ids: List[_typedefs.I32] = field(default_factory=list)
+    checkboxes_ids: Set[_typedefs.I32] = field(default_factory=set)
 
 default_created_date: dates.DateTime = dates.DateTime(
     year=2024, month=12, day=25, hour=0, minute=0, second=0, microsecond=0
 )
 
 class Todo:
-    async def create(self, text: str, type: TodoType) -> int: ...
+    async def create(self, text: _typedefs.String, type: TodoType) -> _typedefs.I32: ...
     async def update(self, item: TodoItem) -> None: ...
-    async def get(self, id: int) -> TodoItem: ...
+    async def get(self, id: _typedefs.I32) -> TodoItem: ...
     async def all(self, pager: shared.LimitOffset) -> List[TodoItem]: ...
-    async def filter(self, ids: List[int]) -> List[TodoItem]: ...
-    async def stats(self) -> Dict[int, float]: ...
-    async def types(self) -> Set[int]: ...
+    async def filter(self, ids: List[_typedefs.I32]) -> List[TodoItem]: ...
+    async def stats(self) -> Dict[_typedefs.I32, _typedefs.Double]: ...
+    async def types(self) -> Set[_typedefs.I16]: ...
     async def groupby(self) -> Dict[TodoType, List[TodoItem]]: ...
-    async def ping(self) -> str: ...
+    async def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/async/todo_v2.pyi
+++ b/tests/stubs/expected/async/todo_v2.pyi
@@ -1,1 +1,3 @@
+from . import _typedefs
+
 class Todo: ...

--- a/tests/stubs/expected/optional/_typedefs.pyi
+++ b/tests/stubs/expected/optional/_typedefs.pyi
@@ -1,0 +1,10 @@
+from typing import Annotated
+
+Binary = Annotated[bytes, {"thrift_type": "BINARY"}]
+Bool = Annotated[bool, {"thrift_type": "BOOL"}]
+Byte = Annotated[int, {"thrift_type": "BYTE"}]
+Double = Annotated[float, {"thrift_type": "DOUBLE"}]
+I16 = Annotated[int, {"thrift_type": "I16"}]
+I32 = Annotated[int, {"thrift_type": "I32"}]
+I64 = Annotated[int, {"thrift_type": "I64"}]
+String = Annotated[str, {"thrift_type": "STRING"}]

--- a/tests/stubs/expected/optional/_typedefs.pyi
+++ b/tests/stubs/expected/optional/_typedefs.pyi
@@ -1,10 +1,15 @@
+from dataclasses import dataclass
 from typing import Annotated
 
-Binary = Annotated[bytes, {"thrift_type": "BINARY"}]
-Bool = Annotated[bool, {"thrift_type": "BOOL"}]
-Byte = Annotated[int, {"thrift_type": "BYTE"}]
-Double = Annotated[float, {"thrift_type": "DOUBLE"}]
-I16 = Annotated[int, {"thrift_type": "I16"}]
-I32 = Annotated[int, {"thrift_type": "I32"}]
-I64 = Annotated[int, {"thrift_type": "I64"}]
-String = Annotated[str, {"thrift_type": "STRING"}]
+@dataclass(frozen=True)
+class Metadata:
+    thrift_type: str
+
+Binary = Annotated[bytes, Metadata(thrift_type="BINARY")]
+Bool = Annotated[bool, Metadata(thrift_type="BOOL")]
+Byte = Annotated[int, Metadata(thrift_type="BYTE")]
+Double = Annotated[float, Metadata(thrift_type="DOUBLE")]
+I16 = Annotated[int, Metadata(thrift_type="I16")]
+I32 = Annotated[int, Metadata(thrift_type="I32")]
+I64 = Annotated[int, Metadata(thrift_type="I64")]
+String = Annotated[str, Metadata(thrift_type="STRING")]

--- a/tests/stubs/expected/optional/dates.pyi
+++ b/tests/stubs/expected/optional/dates.pyi
@@ -1,15 +1,16 @@
 from dataclasses import dataclass
 from typing import *
+from . import _typedefs
 
 @dataclass
 class DateTime:
-    year: Optional[int] = None
-    month: Optional[int] = None
-    day: Optional[int] = None
-    hour: Optional[int] = None
-    minute: Optional[int] = None
-    second: Optional[int] = None
-    microsecond: Optional[int] = None
+    year: Optional[_typedefs.I16] = None
+    month: Optional[_typedefs.Byte] = None
+    day: Optional[_typedefs.Byte] = None
+    hour: Optional[_typedefs.I16] = None
+    minute: Optional[_typedefs.Byte] = None
+    second: Optional[_typedefs.Byte] = None
+    microsecond: Optional[_typedefs.I64] = None
 
 @dataclass
 class Date: ...

--- a/tests/stubs/expected/optional/shared.pyi
+++ b/tests/stubs/expected/optional/shared.pyi
@@ -1,21 +1,22 @@
 from dataclasses import dataclass
 from typing import *
+from . import _typedefs
 
 class NotFound(Exception):
-    message: Optional[str] = "Not Found"
+    message: Optional[_typedefs.String] = "Not Found"
 
-    def __init__(self, message: Optional[str] = "Not Found") -> None: ...
+    def __init__(self, message: Optional[_typedefs.String] = "Not Found") -> None: ...
 
 class EmptyException(Exception): ...
 
 @dataclass
 class LimitOffset:
-    limit: Optional[int] = None
-    offset: Optional[int] = None
+    limit: Optional[_typedefs.I32] = None
+    offset: Optional[_typedefs.I32] = None
 
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
 
 class Service:
-    def ping(self) -> str: ...
+    def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/optional/todo.pyi
+++ b/tests/stubs/expected/optional/todo.pyi
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import *
+from . import _typedefs
 from . import dates
 from . import shared
 
@@ -11,32 +12,32 @@ class TodoType(IntEnum):
 
 @dataclass
 class TodoItem:
-    id: Optional[int] = None
-    text: Optional[str] = None
+    id: Optional[_typedefs.I32] = None
+    text: Optional[_typedefs.String] = None
     type: Optional[TodoType] = None
     created: Optional[dates.DateTime] = None
-    is_deleted: Optional[bool] = None
-    picture: Optional[bytes] = None
-    is_favorite: Optional[bool] = False
+    is_deleted: Optional[_typedefs.Bool] = None
+    picture: Optional[_typedefs.Binary] = None
+    is_favorite: Optional[_typedefs.Bool] = False
 
 @dataclass
 class TodoCounter:
-    todos: Optional[Dict[int, TodoItem]] = field(default_factory=dict)
-    plain_ids: Optional[Set[int]] = field(default_factory=lambda: {1, 2, 3})
-    note_ids: Optional[List[int]] = field(default_factory=list)
-    checkboxes_ids: Optional[Set[int]] = field(default_factory=set)
+    todos: Optional[Dict[_typedefs.I32, TodoItem]] = field(default_factory=dict)
+    plain_ids: Optional[Set[_typedefs.I32]] = field(default_factory=lambda: {1, 2, 3})
+    note_ids: Optional[List[_typedefs.I32]] = field(default_factory=list)
+    checkboxes_ids: Optional[Set[_typedefs.I32]] = field(default_factory=set)
 
 default_created_date: dates.DateTime = dates.DateTime(
     year=2024, month=12, day=25, hour=0, minute=0, second=0, microsecond=0
 )
 
 class Todo:
-    def create(self, text: str, type: TodoType) -> int: ...
+    def create(self, text: _typedefs.String, type: TodoType) -> _typedefs.I32: ...
     def update(self, item: TodoItem) -> None: ...
-    def get(self, id: int) -> TodoItem: ...
+    def get(self, id: _typedefs.I32) -> TodoItem: ...
     def all(self, pager: shared.LimitOffset) -> List[TodoItem]: ...
-    def filter(self, ids: List[int]) -> List[TodoItem]: ...
-    def stats(self) -> Dict[int, float]: ...
-    def types(self) -> Set[int]: ...
+    def filter(self, ids: List[_typedefs.I32]) -> List[TodoItem]: ...
+    def stats(self) -> Dict[_typedefs.I32, _typedefs.Double]: ...
+    def types(self) -> Set[_typedefs.I16]: ...
     def groupby(self) -> Dict[TodoType, List[TodoItem]]: ...
-    def ping(self) -> str: ...
+    def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/optional/todo_v2.pyi
+++ b/tests/stubs/expected/optional/todo_v2.pyi
@@ -1,1 +1,3 @@
+from . import _typedefs
+
 class Todo: ...

--- a/tests/stubs/expected/sync/_typedefs.pyi
+++ b/tests/stubs/expected/sync/_typedefs.pyi
@@ -1,0 +1,10 @@
+from typing import Annotated
+
+Binary = Annotated[bytes, {"thrift_type": "BINARY"}]
+Bool = Annotated[bool, {"thrift_type": "BOOL"}]
+Byte = Annotated[int, {"thrift_type": "BYTE"}]
+Double = Annotated[float, {"thrift_type": "DOUBLE"}]
+I16 = Annotated[int, {"thrift_type": "I16"}]
+I32 = Annotated[int, {"thrift_type": "I32"}]
+I64 = Annotated[int, {"thrift_type": "I64"}]
+String = Annotated[str, {"thrift_type": "STRING"}]

--- a/tests/stubs/expected/sync/_typedefs.pyi
+++ b/tests/stubs/expected/sync/_typedefs.pyi
@@ -1,10 +1,15 @@
+from dataclasses import dataclass
 from typing import Annotated
 
-Binary = Annotated[bytes, {"thrift_type": "BINARY"}]
-Bool = Annotated[bool, {"thrift_type": "BOOL"}]
-Byte = Annotated[int, {"thrift_type": "BYTE"}]
-Double = Annotated[float, {"thrift_type": "DOUBLE"}]
-I16 = Annotated[int, {"thrift_type": "I16"}]
-I32 = Annotated[int, {"thrift_type": "I32"}]
-I64 = Annotated[int, {"thrift_type": "I64"}]
-String = Annotated[str, {"thrift_type": "STRING"}]
+@dataclass(frozen=True)
+class Metadata:
+    thrift_type: str
+
+Binary = Annotated[bytes, Metadata(thrift_type="BINARY")]
+Bool = Annotated[bool, Metadata(thrift_type="BOOL")]
+Byte = Annotated[int, Metadata(thrift_type="BYTE")]
+Double = Annotated[float, Metadata(thrift_type="DOUBLE")]
+I16 = Annotated[int, Metadata(thrift_type="I16")]
+I32 = Annotated[int, Metadata(thrift_type="I32")]
+I64 = Annotated[int, Metadata(thrift_type="I64")]
+String = Annotated[str, Metadata(thrift_type="STRING")]

--- a/tests/stubs/expected/sync/dates.pyi
+++ b/tests/stubs/expected/sync/dates.pyi
@@ -1,15 +1,16 @@
 from dataclasses import dataclass
 from typing import *
+from . import _typedefs
 
 @dataclass
 class DateTime:
-    year: int
-    month: int
-    day: int
-    hour: int
-    minute: int
-    second: int
-    microsecond: Optional[int] = None
+    year: _typedefs.I16
+    month: _typedefs.Byte
+    day: _typedefs.Byte
+    hour: _typedefs.I16
+    minute: _typedefs.Byte
+    second: _typedefs.Byte
+    microsecond: Optional[_typedefs.I64] = None
 
 @dataclass
 class Date: ...

--- a/tests/stubs/expected/sync/shared.pyi
+++ b/tests/stubs/expected/sync/shared.pyi
@@ -1,21 +1,22 @@
 from dataclasses import dataclass
 from typing import *
+from . import _typedefs
 
 class NotFound(Exception):
-    message: Optional[str] = "Not Found"
+    message: Optional[_typedefs.String] = "Not Found"
 
-    def __init__(self, message: Optional[str] = "Not Found") -> None: ...
+    def __init__(self, message: Optional[_typedefs.String] = "Not Found") -> None: ...
 
 class EmptyException(Exception): ...
 
 @dataclass
 class LimitOffset:
-    limit: Optional[int] = None
-    offset: Optional[int] = None
+    limit: Optional[_typedefs.I32] = None
+    offset: Optional[_typedefs.I32] = None
 
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
 
 class Service:
-    def ping(self) -> str: ...
+    def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/sync/todo.pyi
+++ b/tests/stubs/expected/sync/todo.pyi
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import *
+from . import _typedefs
 from . import dates
 from . import shared
 
@@ -11,32 +12,32 @@ class TodoType(IntEnum):
 
 @dataclass
 class TodoItem:
-    id: int
-    text: str
+    id: _typedefs.I32
+    text: _typedefs.String
     type: TodoType
     created: dates.DateTime
-    is_deleted: bool
-    picture: Optional[bytes] = None
-    is_favorite: bool = False
+    is_deleted: _typedefs.Bool
+    picture: Optional[_typedefs.Binary] = None
+    is_favorite: _typedefs.Bool = False
 
 @dataclass
 class TodoCounter:
-    todos: Dict[int, TodoItem] = field(default_factory=dict)
-    plain_ids: Set[int] = field(default_factory=lambda: {1, 2, 3})
-    note_ids: List[int] = field(default_factory=list)
-    checkboxes_ids: Set[int] = field(default_factory=set)
+    todos: Dict[_typedefs.I32, TodoItem] = field(default_factory=dict)
+    plain_ids: Set[_typedefs.I32] = field(default_factory=lambda: {1, 2, 3})
+    note_ids: List[_typedefs.I32] = field(default_factory=list)
+    checkboxes_ids: Set[_typedefs.I32] = field(default_factory=set)
 
 default_created_date: dates.DateTime = dates.DateTime(
     year=2024, month=12, day=25, hour=0, minute=0, second=0, microsecond=0
 )
 
 class Todo:
-    def create(self, text: str, type: TodoType) -> int: ...
+    def create(self, text: _typedefs.String, type: TodoType) -> _typedefs.I32: ...
     def update(self, item: TodoItem) -> None: ...
-    def get(self, id: int) -> TodoItem: ...
+    def get(self, id: _typedefs.I32) -> TodoItem: ...
     def all(self, pager: shared.LimitOffset) -> List[TodoItem]: ...
-    def filter(self, ids: List[int]) -> List[TodoItem]: ...
-    def stats(self) -> Dict[int, float]: ...
-    def types(self) -> Set[int]: ...
+    def filter(self, ids: List[_typedefs.I32]) -> List[TodoItem]: ...
+    def stats(self) -> Dict[_typedefs.I32, _typedefs.Double]: ...
+    def types(self) -> Set[_typedefs.I16]: ...
     def groupby(self) -> Dict[TodoType, List[TodoItem]]: ...
-    def ping(self) -> str: ...
+    def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/sync/todo_v2.pyi
+++ b/tests/stubs/expected/sync/todo_v2.pyi
@@ -1,1 +1,3 @@
+from . import _typedefs
+
 class Todo: ...

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,14 @@ def test_main(capsys, expected_dir, args):
 
     main([input_dir, "--output", output_dir, *args])
 
-    pyi_files = ["__init__.pyi", "dates.pyi", "shared.pyi", "todo.pyi", "todo_v2.pyi"]
+    pyi_files = [
+        "__init__.pyi",
+        "_typedefs.pyi",
+        "dates.pyi",
+        "shared.pyi",
+        "todo.pyi",
+        "todo_v2.pyi",
+    ]
     match, mismatch, errors = filecmp.cmpfiles(output_dir, expected_dir, pyi_files)
     assert errors == []
     assert mismatch == []


### PR DESCRIPTION
close #56