### PR TITLE
Use `default_factory` when default field is a (generated) `@dataclass`

### DIFF
--- a/example/interfaces/todo.thrift
+++ b/example/interfaces/todo.thrift
@@ -29,7 +29,8 @@ struct TodoItem {
     4: required dates.DateTime created
     5: required bool is_deleted
     6: optional binary picture
-    7: required bool is_favorite = false
+    7: required dates.DateTime createdWithDefault = dates.EPOCH
+    8: required bool is_favorite = false
 }
 
 

--- a/src/thriftpyi/entities.py
+++ b/src/thriftpyi/entities.py
@@ -2,15 +2,7 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass, field
-from typing import (
-    TYPE_CHECKING,
-    MutableMapping,
-    MutableSequence,
-    MutableSet,
-    Sequence,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Hashable, Sequence, Type, Union
 
 if TYPE_CHECKING:
     AnyFunctionDef = Union[ast.AsyncFunctionDef, ast.FunctionDef]
@@ -202,7 +194,7 @@ class Field:
 @dataclass
 class StructField(Field):
     def _make_ast_value(self) -> ast.expr:
-        if isinstance(self.value, (MutableSequence, MutableSet, MutableMapping)):
+        if not isinstance(self.value, Hashable):
             if self.value:
                 value = ast.Lambda(
                     args=[], body=ast.Constant(value=self.value, kind=None)

--- a/tests/stubs/expected/async/todo.pyi
+++ b/tests/stubs/expected/async/todo.pyi
@@ -18,6 +18,11 @@ class TodoItem:
     created: dates.DateTime
     is_deleted: _typedefs.Bool
     picture: Optional[_typedefs.Binary] = None
+    createdWithDefault: dates.DateTime = field(
+        default_factory=lambda: DateTime(
+            year=1970, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+        )
+    )
     is_favorite: _typedefs.Bool = False
 
 @dataclass

--- a/tests/stubs/expected/optional/todo.pyi
+++ b/tests/stubs/expected/optional/todo.pyi
@@ -18,6 +18,11 @@ class TodoItem:
     created: Optional[dates.DateTime] = None
     is_deleted: Optional[_typedefs.Bool] = None
     picture: Optional[_typedefs.Binary] = None
+    createdWithDefault: Optional[dates.DateTime] = field(
+        default_factory=lambda: DateTime(
+            year=1970, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+        )
+    )
     is_favorite: Optional[_typedefs.Bool] = False
 
 @dataclass

--- a/tests/stubs/expected/sync/todo.pyi
+++ b/tests/stubs/expected/sync/todo.pyi
@@ -18,6 +18,11 @@ class TodoItem:
     created: dates.DateTime
     is_deleted: _typedefs.Bool
     picture: Optional[_typedefs.Binary] = None
+    createdWithDefault: dates.DateTime = field(
+        default_factory=lambda: DateTime(
+            year=1970, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+        )
+    )
     is_favorite: _typedefs.Bool = False
 
 @dataclass


### PR DESCRIPTION
Addresses: https://github.com/unmade/thrift-pyi/issues/58

This issue was only apparent in Python 3.11: 

![image](https://github.com/user-attachments/assets/c52cc686-e6c9-4e62-b4d7-926274c200f9)


but should also be backwards compatible with any 3.x.