### PR TITLE
Fix call when struct field has a default value that comes from another module/import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: 22.6.0
     hooks:
     -   id: black
--   repo: https://github.com/humitos/mirrors-autoflake
+-   repo: https://github.com/PyCQA/autoflake
     rev: v1.1
     hooks:
     -   id: autoflake

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/autoflake
-    rev: v1.1
+    rev: v2.3.1
     hooks:
     -   id: autoflake
 -   repo: https://github.com/pre-commit/mirrors-isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "thrift-pyi"
-version = "2.2.0"
+version = "2.3.0"
 description = "This is simple `.pyi` stubs generator from thrift interfaces"
 readme = "README.rst"
 repository = "https://github.com/unmade/thrift-pyi"

--- a/src/thriftpyi/entities.py
+++ b/src/thriftpyi/entities.py
@@ -194,9 +194,7 @@ class StructField(Field):
     def _make_ast_value(self) -> ast.expr:
         if not isinstance(self.value, Hashable):
             if self.value:
-                value = ast.Lambda(
-                    args=[], body=ast.Constant(value=self.value, kind=None)
-                )
+                value = ast.Lambda(args=[], body=super()._make_ast_value())
             else:
                 value = ast.Name(id=self.value.__class__.__name__, ctx=ast.Load())
 

--- a/tests/stubs/expected/async/todo.pyi
+++ b/tests/stubs/expected/async/todo.pyi
@@ -19,7 +19,7 @@ class TodoItem:
     is_deleted: _typedefs.Bool
     picture: Optional[_typedefs.Binary] = None
     createdWithDefault: dates.DateTime = field(
-        default_factory=lambda: DateTime(
+        default_factory=lambda: dates.DateTime(
             year=1970, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
         )
     )

--- a/tests/stubs/expected/frozen/todo.pyi
+++ b/tests/stubs/expected/frozen/todo.pyi
@@ -19,7 +19,7 @@ class TodoItem:
     is_deleted: Optional[_typedefs.Bool] = None
     picture: Optional[_typedefs.Binary] = None
     createdWithDefault: Optional[dates.DateTime] = field(
-        default_factory=lambda: DateTime(
+        default_factory=lambda: dates.DateTime(
             year=1970, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
         )
     )

--- a/tests/stubs/expected/frozen_kw_only/todo.pyi
+++ b/tests/stubs/expected/frozen_kw_only/todo.pyi
@@ -19,7 +19,7 @@ class TodoItem:
     is_deleted: Optional[_typedefs.Bool] = None
     picture: Optional[_typedefs.Binary] = None
     createdWithDefault: Optional[dates.DateTime] = field(
-        default_factory=lambda: DateTime(
+        default_factory=lambda: dates.DateTime(
             year=1970, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
         )
     )

--- a/tests/stubs/expected/frozen_kw_only_sync/todo.pyi
+++ b/tests/stubs/expected/frozen_kw_only_sync/todo.pyi
@@ -19,7 +19,7 @@ class TodoItem:
     is_deleted: _typedefs.Bool
     picture: Optional[_typedefs.Binary] = None
     createdWithDefault: dates.DateTime = field(
-        default_factory=lambda: DateTime(
+        default_factory=lambda: dates.DateTime(
             year=1970, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
         )
     )

--- a/tests/stubs/expected/kw_only/todo.pyi
+++ b/tests/stubs/expected/kw_only/todo.pyi
@@ -19,7 +19,7 @@ class TodoItem:
     is_deleted: Optional[_typedefs.Bool] = None
     picture: Optional[_typedefs.Binary] = None
     createdWithDefault: Optional[dates.DateTime] = field(
-        default_factory=lambda: DateTime(
+        default_factory=lambda: dates.DateTime(
             year=1970, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
         )
     )

--- a/tests/stubs/expected/optional/todo.pyi
+++ b/tests/stubs/expected/optional/todo.pyi
@@ -19,7 +19,7 @@ class TodoItem:
     is_deleted: Optional[_typedefs.Bool] = None
     picture: Optional[_typedefs.Binary] = None
     createdWithDefault: Optional[dates.DateTime] = field(
-        default_factory=lambda: DateTime(
+        default_factory=lambda: dates.DateTime(
             year=1970, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
         )
     )

--- a/tests/stubs/expected/sync/todo.pyi
+++ b/tests/stubs/expected/sync/todo.pyi
@@ -19,7 +19,7 @@ class TodoItem:
     is_deleted: _typedefs.Bool
     picture: Optional[_typedefs.Binary] = None
     createdWithDefault: dates.DateTime = field(
-        default_factory=lambda: DateTime(
+        default_factory=lambda: dates.DateTime(
             year=1970, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
         )
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
-import ast
 import filecmp
 import shutil
-from pathlib import Path
+import sys
 
 import pytest
 
@@ -40,19 +39,108 @@ def test_main(capsys, expected_dir, args):
         "todo_v2.pyi",
     ]
 
-    # Validate that all generated files are syntactically valid Python
-    for pyi_file in pyi_files:
-        file_path = Path(output_dir) / pyi_file
-        with open(file_path) as f:
-            content = f.read()
-            try:
-                ast.parse(content)
-            except SyntaxError as e:
-                pytest.fail(f"Generated file {pyi_file} has invalid Python syntax: {e}")
-
     # Check that files match expected output
     match, mismatch, errors = filecmp.cmpfiles(output_dir, expected_dir, pyi_files)
     assert errors == []
     assert mismatch == []
     assert match == pyi_files
     shutil.rmtree(output_dir)
+
+
+def test_generated_code_is_importable(tmp_path):
+    """Test that generated code can actually be imported and used."""
+    input_dir = "example/interfaces"
+    output_dir = tmp_path / "generated"
+
+    # Generate stubs with frozen option (without kw_only)
+    main([input_dir, "--output", str(output_dir), "--frozen"])
+
+    # Copy .pyi files to .py files so they can be imported
+    for pyi_file in output_dir.glob("*.pyi"):
+        py_file = pyi_file.with_suffix(".py")
+        py_file.write_text(pyi_file.read_text())
+
+    # Create __init__.py to make it a proper package
+    (output_dir / "__init__.py").write_text("")
+
+    # Create a test script that imports and uses the generated code
+    test_script = tmp_path / "test_import.py"
+    test_script.write_text(
+        """
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent))
+
+# Import the generated package (not individual modules)
+from generated import todo
+
+# Try to instantiate TodoItem with defaults
+# This will raise NameError if the lambda references undefined DateTime
+item = todo.TodoItem()
+print("Success: TodoItem instantiated")
+"""
+    )
+
+    # Run the test script
+    import subprocess
+
+    result = subprocess.run(
+        [sys.executable, str(test_script)], capture_output=True, text=True
+    )
+
+    # Check for NameError specifically
+    assert (
+        "NameError" not in result.stderr
+    ), f"Generated code has undefined names: {result.stderr}"
+    assert result.returncode == 0, f"Failed to run generated code: {result.stderr}"
+    assert "Success" in result.stdout
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="kw_only requires Python 3.10+")
+def test_generated_code_with_kw_only_is_importable(tmp_path):
+    """Test that generated code with kw_only can actually be imported and used."""
+    input_dir = "example/interfaces"
+    output_dir = tmp_path / "generated"
+
+    # Generate stubs with frozen + kw_only options (the case that had the bug)
+    main([input_dir, "--output", str(output_dir), "--frozen", "--kw-only"])
+
+    # Copy .pyi files to .py files so they can be imported
+    for pyi_file in output_dir.glob("*.pyi"):
+        py_file = pyi_file.with_suffix(".py")
+        py_file.write_text(pyi_file.read_text())
+
+    # Create __init__.py to make it a proper package
+    (output_dir / "__init__.py").write_text("")
+
+    # Create a test script that imports and uses the generated code
+    test_script = tmp_path / "test_import.py"
+    test_script.write_text(
+        """
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent))
+
+# Import the generated package (not individual modules)
+from generated import todo
+
+# Try to instantiate TodoItem with defaults
+# This will raise NameError if the lambda references undefined DateTime
+item = todo.TodoItem()
+print("Success: TodoItem instantiated")
+"""
+    )
+
+    # Run the test script
+    import subprocess
+
+    result = subprocess.run(
+        [sys.executable, str(test_script)], capture_output=True, text=True
+    )
+
+    # Check for NameError specifically
+    assert (
+        "NameError" not in result.stderr
+    ), f"Generated code has undefined names: {result.stderr}"
+    assert result.returncode == 0, f"Failed to run generated code: {result.stderr}"
+    assert "Success" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import filecmp
 import shutil
+import subprocess
 import sys
 
 import pytest
@@ -82,10 +83,8 @@ print("Success: TodoItem instantiated")
     )
 
     # Run the test script
-    import subprocess
-
     result = subprocess.run(
-        [sys.executable, str(test_script)], capture_output=True, text=True
+        [sys.executable, str(test_script)], capture_output=True, text=True, check=False
     )
 
     # Check for NameError specifically
@@ -96,7 +95,9 @@ print("Success: TodoItem instantiated")
     assert "Success" in result.stdout
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="kw_only requires Python 3.10+")  # pragma: no cover
+@pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="kw_only requires Python 3.10+"
+)  # pragma: no cover
 def test_generated_code_with_kw_only_is_importable(tmp_path):  # pragma: no cover
     """Test that generated code with kw_only can actually be imported and used."""
     input_dir = "example/interfaces"
@@ -132,10 +133,8 @@ print("Success: TodoItem instantiated")
     )
 
     # Run the test script
-    import subprocess
-
     result = subprocess.run(
-        [sys.executable, str(test_script)], capture_output=True, text=True
+        [sys.executable, str(test_script)], capture_output=True, text=True, check=False
     )
 
     # Check for NameError specifically

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
+import ast
 import filecmp
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -37,6 +39,18 @@ def test_main(capsys, expected_dir, args):
         "todo.pyi",
         "todo_v2.pyi",
     ]
+
+    # Validate that all generated files are syntactically valid Python
+    for pyi_file in pyi_files:
+        file_path = Path(output_dir) / pyi_file
+        with open(file_path) as f:
+            content = f.read()
+            try:
+                ast.parse(content)
+            except SyntaxError as e:
+                pytest.fail(f"Generated file {pyi_file} has invalid Python syntax: {e}")
+
+    # Check that files match expected output
     match, mismatch, errors = filecmp.cmpfiles(output_dir, expected_dir, pyi_files)
     assert errors == []
     assert mismatch == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,8 +96,8 @@ print("Success: TodoItem instantiated")
     assert "Success" in result.stdout
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="kw_only requires Python 3.10+")
-def test_generated_code_with_kw_only_is_importable(tmp_path):
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="kw_only requires Python 3.10+")  # pragma: no cover
+def test_generated_code_with_kw_only_is_importable(tmp_path):  # pragma: no cover
     """Test that generated code with kw_only can actually be imported and used."""
     input_dir = "example/interfaces"
     output_dir = tmp_path / "generated"


### PR DESCRIPTION
### PR

This PR fixes the scenario when a certain thrift `struct` has a field that (1) has a default value and (2) the type of that field comes from another module/import. 

I think in the past, we fixed this case for `const`, which already generated code as follows:

```python
default_created_date: dates.DateTime = dates.DateTime(
    year=2024, month=12, day=25, hour=0, minute=0, second=0, microsecond=0
)
```

### Panic

When I went to add tests, I realized we ALREADY had tests for this case:

```thrift
include "dates.thrift"

...

struct TodoItem {
    1: required i32 id
    2: required string text
    3: required TodoType type
    4: required dates.DateTime created
    5: required bool is_deleted
    6: optional binary picture
    7: required dates.DateTime createdWithDefault = dates.EPOCH
    8: required bool is_favorite = false
}
```

which generated the following (incorrect) code:

```python
from . import dates

...

@dataclass(frozen=True, kw_only=True)
class TodoItem:
    id: _typedefs.I32
    text: _typedefs.String
    type: TodoType
    created: dates.DateTime
    is_deleted: _typedefs.Bool
    picture: Optional[_typedefs.Binary] = None
    createdWithDefault: dates.DateTime = field(
        default_factory=lambda: DateTime(
            year=1970, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
        )
    )
    is_favorite: _typedefs.Bool = False
```

The problem is that the tests only check files against the hardcoded expectation, but does not try to validate that they are valid Python.

I have added a step to the unit tests to validate Python syntax as well.


### Appendix

This code largely tries to borrow from `entities.Field` and `TModuleProxy._make_const` which has the following simple definition:

```python
    def _make_const(self, tconst) -> Field:
        name, value = tconst

        known_modules = {
            module.__name__ for module in self.tmodule.__thrift_meta__["includes"]
        }

        module_name = None
        if hasattr(value, "__class__"):
            module_name = value.__class__.__module__
            if module_name not in known_modules:
                module_name = None

        return Field(
            name=name,
            type=guess_type(
                value,
                known_modules=known_modules,
                known_structs=self.tmodule.__thrift_meta__["structs"],
            ),
            value=value,
            module=module_name,
            required=True,
        )
```

Unfortunately I did not see an easy way to get it to re-use more code but I admit I did not really think too deeply about possible changes to the type hierarchy (I am a bit scared to touch the OOP concepts here).

Very open if you have suggestions for different approaches.