### PR TITLE
Fix for `StopIteration` on empty const collections (#62)

### DIFF
--- a/example/interfaces/shared.thrift
+++ b/example/interfaces/shared.thrift
@@ -7,6 +7,9 @@ exception EmptyException {}
 const i32 INT_CONST_1 = 1234
 const map<string,string> MAP_CONST = {"hello": "world", "goodnight": "moon"}
 const i32 INT_CONST_2 = 1234
+const list<string> EMPTY_LIST = []
+const map<string,i32> EMPTY_MAP = {}
+const set<i32> EMPTY_SET = []
 
 struct LimitOffset {
     1: optional i32 limit

--- a/src/thriftpyi/utils.py
+++ b/src/thriftpyi/utils.py
@@ -14,6 +14,8 @@ def guess_type(  # pylint: disable=too-many-branches
 
     if isinstance(value, Mapping):
         type_ = type(value).__name__.capitalize()
+        if not value:
+            return f"{type_}[Any, Any]"
         key_type = guess_type(
             next(iter(value.keys())),
             known_modules=known_modules,
@@ -28,6 +30,8 @@ def guess_type(  # pylint: disable=too-many-branches
 
     if isinstance(value, Collection):
         type_ = type(value).__name__.capitalize()
+        if not value:
+            return f"{type_}[Any]"
         item_type = guess_type(
             next(iter(value)), known_modules=known_modules, known_structs=known_structs
         )

--- a/tests/stubs/expected/async/shared.pyi
+++ b/tests/stubs/expected/async/shared.pyi
@@ -17,6 +17,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     async def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/frozen/shared.pyi
+++ b/tests/stubs/expected/frozen/shared.pyi
@@ -17,6 +17,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/frozen_kw_only/shared.pyi
+++ b/tests/stubs/expected/frozen_kw_only/shared.pyi
@@ -17,6 +17,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/frozen_kw_only_sync/shared.pyi
+++ b/tests/stubs/expected/frozen_kw_only_sync/shared.pyi
@@ -17,6 +17,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/kw_only/shared.pyi
+++ b/tests/stubs/expected/kw_only/shared.pyi
@@ -17,6 +17,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/optional/shared.pyi
+++ b/tests/stubs/expected/optional/shared.pyi
@@ -17,6 +17,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/sync/shared.pyi
+++ b/tests/stubs/expected/sync/shared.pyi
@@ -17,6 +17,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     def ping(self) -> _typedefs.String: ...

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,6 +42,9 @@ class TestGuessType:
             ({1, 2}, "Set[int]"),
             ([1, 2], "List[int]"),
             ({"1": "2"}, "Dict[str, str]"),
+            ([], "List[Any]"),
+            ({}, "Dict[Any, Any]"),
+            (set(), "Set[Any]"),
         ],
     )
     def test(self, guess_type, value, expected: str):


### PR DESCRIPTION
Fixes:

- #62

Let me know if there's more nuance here - I gather that there's some problems from `thriftpy2` that prevent us from getting rich type info for const containers compared to struct fields.
