### PR TITLE
Improve const support

### DIFF
--- a/example/app/interfaces/shared.pyi
+++ b/example/app/interfaces/shared.pyi
@@ -18,6 +18,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     def ping(self) -> _typedefs.String: ...

--- a/example/app/interfaces/shared.pyi
+++ b/example/app/interfaces/shared.pyi
@@ -18,7 +18,7 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
-EMPTY_LIST: List[Any] = []
+EMPTY_LIST: List[str] = []
 EMPTY_MAP: Dict[Any, Any] = {}
 EMPTY_SET: Set[Any] = set()
 

--- a/example/interfaces/shared.thrift
+++ b/example/interfaces/shared.thrift
@@ -8,6 +8,10 @@ const i32 INT_CONST_1 = 1234
 const map<string,string> MAP_CONST = {"hello": "world", "goodnight": "moon"}
 const i32 INT_CONST_2 = 1234
 
+const list<string> EMPTY_LIST = []
+const map<string,i32> EMPTY_MAP = {}
+const set<i32> EMPTY_SET = []
+
 struct LimitOffset {
     1: optional i32 limit
     2: optional i32 offset

--- a/example/interfaces/shared.thrift
+++ b/example/interfaces/shared.thrift
@@ -8,7 +8,7 @@ const i32 INT_CONST_1 = 1234
 const map<string,string> MAP_CONST = {"hello": "world", "goodnight": "moon"}
 const i32 INT_CONST_2 = 1234
 
-const list<string> EMPTY_LIST = []
+const list<string> EMPTY_LIST = []  ( thriftpyi.type = "List[str]" )
 const map<string,i32> EMPTY_MAP = {}
 const set<i32> EMPTY_SET = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "thrift-pyi"
-version = "2.5.0"
+version = "2.6.0"
 description = "This is simple `.pyi` stubs generator from thrift interfaces"
 readme = "README.rst"
 repository = "https://github.com/unmade/thrift-pyi"

--- a/src/thriftpyi/proxies.py
+++ b/src/thriftpyi/proxies.py
@@ -63,9 +63,13 @@ class TModuleProxy:
         module_name_map = self._get_module_name_map()
         patch_value_repr(value, module_name_map)
 
+        const_annotations = getattr(self.tmodule, "__thrift_const_annotations__", {})
+        pytype = const_annotations.get(name, {}).get("thriftpyi.type")
+
         return Field(
             name=name,
-            type=guess_type(
+            type=pytype
+            or guess_type(
                 value,
                 module_name_map=module_name_map,
                 known_structs=self.tmodule.__thrift_meta__["structs"],

--- a/src/thriftpyi/utils.py
+++ b/src/thriftpyi/utils.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from thriftpy2.thrift import TType
 
+_NO_TYPE = object()
+
 
 def guess_type(  # pylint: disable=too-many-branches
     value,
@@ -19,12 +21,12 @@ def guess_type(  # pylint: disable=too-many-branches
     if isinstance(value, Mapping):
         type_ = type(value).__name__.capitalize()
         key_type = guess_type(
-            next(iter(value.keys())),
+            next(iter(value.keys()), _NO_TYPE),
             module_name_map=module_name_map,
             known_structs=known_structs,
         )
         value_type = guess_type(
-            next(iter(value.values())),
+            next(iter(value.values()), _NO_TYPE),
             module_name_map=module_name_map,
             known_structs=known_structs,
         )
@@ -33,7 +35,7 @@ def guess_type(  # pylint: disable=too-many-branches
     if isinstance(value, Collection):
         type_ = type(value).__name__.capitalize()
         item_type = guess_type(
-            next(iter(value)),
+            next(iter(value), None),
             module_name_map=module_name_map,
             known_structs=known_structs,
         )

--- a/tests/stubs/expected/async/shared.pyi
+++ b/tests/stubs/expected/async/shared.pyi
@@ -18,6 +18,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     async def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/async/shared.pyi
+++ b/tests/stubs/expected/async/shared.pyi
@@ -18,7 +18,7 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
-EMPTY_LIST: List[Any] = []
+EMPTY_LIST: List[str] = []
 EMPTY_MAP: Dict[Any, Any] = {}
 EMPTY_SET: Set[Any] = set()
 

--- a/tests/stubs/expected/frozen/shared.pyi
+++ b/tests/stubs/expected/frozen/shared.pyi
@@ -18,6 +18,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/frozen/shared.pyi
+++ b/tests/stubs/expected/frozen/shared.pyi
@@ -18,7 +18,7 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
-EMPTY_LIST: List[Any] = []
+EMPTY_LIST: List[str] = []
 EMPTY_MAP: Dict[Any, Any] = {}
 EMPTY_SET: Set[Any] = set()
 

--- a/tests/stubs/expected/frozen_kw_only/shared.pyi
+++ b/tests/stubs/expected/frozen_kw_only/shared.pyi
@@ -18,6 +18,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/frozen_kw_only/shared.pyi
+++ b/tests/stubs/expected/frozen_kw_only/shared.pyi
@@ -18,7 +18,7 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
-EMPTY_LIST: List[Any] = []
+EMPTY_LIST: List[str] = []
 EMPTY_MAP: Dict[Any, Any] = {}
 EMPTY_SET: Set[Any] = set()
 

--- a/tests/stubs/expected/frozen_kw_only_sync/shared.pyi
+++ b/tests/stubs/expected/frozen_kw_only_sync/shared.pyi
@@ -18,6 +18,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/frozen_kw_only_sync/shared.pyi
+++ b/tests/stubs/expected/frozen_kw_only_sync/shared.pyi
@@ -18,7 +18,7 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
-EMPTY_LIST: List[Any] = []
+EMPTY_LIST: List[str] = []
 EMPTY_MAP: Dict[Any, Any] = {}
 EMPTY_SET: Set[Any] = set()
 

--- a/tests/stubs/expected/kw_only/shared.pyi
+++ b/tests/stubs/expected/kw_only/shared.pyi
@@ -18,6 +18,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/kw_only/shared.pyi
+++ b/tests/stubs/expected/kw_only/shared.pyi
@@ -18,7 +18,7 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
-EMPTY_LIST: List[Any] = []
+EMPTY_LIST: List[str] = []
 EMPTY_MAP: Dict[Any, Any] = {}
 EMPTY_SET: Set[Any] = set()
 

--- a/tests/stubs/expected/optional/shared.pyi
+++ b/tests/stubs/expected/optional/shared.pyi
@@ -18,6 +18,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/optional/shared.pyi
+++ b/tests/stubs/expected/optional/shared.pyi
@@ -18,7 +18,7 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
-EMPTY_LIST: List[Any] = []
+EMPTY_LIST: List[str] = []
 EMPTY_MAP: Dict[Any, Any] = {}
 EMPTY_SET: Set[Any] = set()
 

--- a/tests/stubs/expected/sync/shared.pyi
+++ b/tests/stubs/expected/sync/shared.pyi
@@ -18,6 +18,9 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
+EMPTY_LIST: List[Any] = []
+EMPTY_MAP: Dict[Any, Any] = {}
+EMPTY_SET: Set[Any] = set()
 
 class Service:
     def ping(self) -> _typedefs.String: ...

--- a/tests/stubs/expected/sync/shared.pyi
+++ b/tests/stubs/expected/sync/shared.pyi
@@ -18,7 +18,7 @@ class LimitOffset:
 INT_CONST_1: int = 1234
 MAP_CONST: Dict[str, str] = {"hello": "world", "goodnight": "moon"}
 INT_CONST_2: int = 1234
-EMPTY_LIST: List[Any] = []
+EMPTY_LIST: List[str] = []
 EMPTY_MAP: Dict[Any, Any] = {}
 EMPTY_SET: Set[Any] = set()
 


### PR DESCRIPTION
As indicated in https://github.com/unmade/thrift-pyi/pull/63

Whenever an empty collection was used as a value for const we hit `StopIteration`. This PR fixes it. 

There is another issue with `const` values and empty collections - `thriftpy2` does not provide any info about original types in the stub for `const`. Thus, after loading the module we only have const names and values. For non-empty collection we try to infer type from the first item in the collection.

This PR adds support to provide custom type for const using `thriftpyi.type` annotation:

```thrift
const list<string> EMPTY_LIST = []  ( thriftpyi.type = "List[str]" )
```

When provided it will be generated as follows:

```python
EMPTY_LIST: List[str] = []
```